### PR TITLE
add conn close process

### DIFF
--- a/pkg/stream/http/stream.go
+++ b/pkg/stream/http/stream.go
@@ -1167,7 +1167,19 @@ func (s *serverStream) endStream() error {
 	}
 	defer s.DestroyStream()
 
-	err := s.doSend()
+	done := make(chan error, 1)
+	utils.GoWithRecover(func() {
+		err := s.doSend()
+		done <- err
+	}, nil)
+
+	var err error
+	select {
+	case err = <-done:
+	case <-s.connection.connClosed:
+		err = errors.New("stream connection closed")
+	}
+
 	s.responseDoneChan <- true
 
 	if resetConn {


### PR DESCRIPTION
目前的实现，在http stream的链路中，最终协程会阻塞在vendor/mosn.io/mosn/pkg/stream/http/stream.go:1145的doSend函数中，如下：
<img width="2142" height="1548" alt="image" src="https://github.com/user-attachments/assets/3337e4e8-419b-4a37-bcf1-754c0b13b188" />
这个doSend函数的实现是一直等待数据，如果有则写回给client，如果写回报错则返回err。这样实现的问题是当client跟mosn的连接断开以后且服务端一直没有数据返回时就无法触发doSend返回err，因此会导致这个协程一直卡在这里，进而导致mosn跟server的连接无法释放。

我们期望的逻辑是当client跟mosn的连接断开以后，即使是在没有任何数据返回的场景下该协程也能感知到该事件，进而让doSend也能正常结束。

因此在改动上，通过一个新的协程处理doSend，然后在主协程中同时监听doSend err跟conn close事件，这一动作会让endStream()在异常情况下正常完成执行，进而触发一系列的回收操作，进而让新的doSend协程也顺利退出